### PR TITLE
Replace fontawesome icons with new icon component

### DIFF
--- a/src/components/ActionsColumn.tsx
+++ b/src/components/ActionsColumn.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { getIconByName } from "@/lib/iconMapping";
+import Icon from "@/components/ui/Icon";
 import { useGridActions, GridAction } from "@/hooks/useGridActions";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
@@ -54,10 +53,9 @@ const ActionsColumn: React.FC<ActionsColumnProps> = ({
       >
         {gridActions.map((gridAction: GridAction) => {
           const { action } = gridAction;
-          const icon = getIconByName(action.icon);
           
-          if (!icon) {
-            console.warn(`Icon not found for action: ${action.icon}`);
+          if (!action.icon) {
+            console.warn(`Icon not found for action: ${action.name}`);
             return null;
           }
 
@@ -72,8 +70,8 @@ const ActionsColumn: React.FC<ActionsColumnProps> = ({
                   aria-label={action.tooltip}
                   title={action.tooltip}
                 >
-                  <FontAwesomeIcon 
-                    icon={icon} 
+                  <Icon 
+                    icon={action.icon} 
                     className="w-4 h-4 text-gray-600 hover:text-gray-800" 
                   />
                 </button>

--- a/src/components/AllProvidersHeader.tsx
+++ b/src/components/AllProvidersHeader.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef } from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSearch, faTimes, faUser, faPlus } from "@fortawesome/free-solid-svg-icons";
+import Icon from "@/components/ui/Icon";
 import { useQuery } from "@tanstack/react-query";
 import { fetchProviders } from "@/lib/supabaseClient";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -98,7 +97,7 @@ const AllProvidersHeader = React.forwardRef<HTMLElement, AllProvidersHeaderProps
           <div className="flex items-center gap-4 mb-2">
             {/* User Icon in Circle */}
             <div className="flex-shrink-0 w-12 h-12 rounded-full border border-gray-300 bg-gray-100 flex items-center justify-center" aria-hidden="true">
-              <FontAwesomeIcon icon={faUser} className="w-8 h-8 text-gray-400" />
+              <Icon icon="user" className="w-8 h-8 text-gray-400" />
             </div>
             <div className="flex flex-col">
               <h1 className="font-bold text-base text-[#545454]">
@@ -148,11 +147,11 @@ const AllProvidersHeader = React.forwardRef<HTMLElement, AllProvidersHeaderProps
                 aria-label="Clear search"
                 data-testid="clear-search-button"
               >
-                <FontAwesomeIcon icon={faTimes} className="w-4 h-4" aria-hidden="true" />
+                <Icon icon="times" className="w-4 h-4" aria-hidden="true" />
               </button>
             )}
-            <FontAwesomeIcon
-              icon={faSearch}
+            <Icon
+              icon="search"
               className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
               aria-hidden="true"
             />
@@ -220,7 +219,7 @@ const AllProvidersHeader = React.forwardRef<HTMLElement, AllProvidersHeaderProps
               data-testid="add-provider-button"
               // onClick={handleAddProvider}
             >
-              <FontAwesomeIcon icon={faPlus} className="w-4 h-4" aria-hidden="true" />
+              <Icon icon="plus" className="w-4 h-4" aria-hidden="true" />
               Add Provider
             </button>
           )}

--- a/src/components/FileDropzone.tsx
+++ b/src/components/FileDropzone.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useDropzone } from 'react-dropzone';
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faUpload } from "@fortawesome/free-solid-svg-icons";
+import Icon from "@/components/ui/Icon";
 
 interface FileDropzoneProps {
   onFilesAccepted: (files: File[]) => void;
@@ -38,7 +37,7 @@ const FileDropzone: React.FC<FileDropzoneProps> = ({ onFilesAccepted }) => {
     >
       <input {...getInputProps()} />
       <div className="flex flex-col items-center" id="file-dropzone-description">
-        <FontAwesomeIcon icon={faUpload} className="text-2xl mb-2 text-gray-600" aria-label="upload" />
+        <Icon icon="upload" className="text-2xl mb-2 text-gray-600" aria-label="upload" />
         <span className="text-gray-700">Drop documents here or <span className="text-blue-600 underline">Click here to browse</span></span>
         <span className="text-xs text-gray-400 mt-2">PDF, DOCX, TXT, RTF, GIF, JPG, PNG</span>
       </div>

--- a/src/components/GridItemDetailsHeader.tsx
+++ b/src/components/GridItemDetailsHeader.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faUpRightAndDownLeftFromCenter, faXmark } from "@fortawesome/free-solid-svg-icons";
+import Icon from "@/components/ui/Icon";
 
 interface GridItemDetailsHeaderProps {
   headerText: string;
@@ -36,8 +35,8 @@ const GridItemDetailsHeader: React.FC<GridItemDetailsHeaderProps> = ({
           aria-label="Expand details modal"
           data-testid="expand-detail-modal-button"
         >
-          <FontAwesomeIcon
-            icon={faUpRightAndDownLeftFromCenter}
+          <Icon
+            icon="expand"
             className="w-5 h-5"
           />
         </button>
@@ -50,7 +49,7 @@ const GridItemDetailsHeader: React.FC<GridItemDetailsHeaderProps> = ({
           aria-label={`Close sidepanel`}
           data-testid={`close-sidepanel-button`}
         >
-          <FontAwesomeIcon icon={faXmark} className="w-5 h-5" />
+          <Icon icon="xmark" className="w-5 h-5" />
         </button>
       )}
     </div>

--- a/src/components/inputs/SingleSelect.tsx
+++ b/src/components/inputs/SingleSelect.tsx
@@ -1,12 +1,6 @@
 import * as React from "react";
 import { ChevronDown, X } from "lucide-react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faCaretDown,
-  faTimes,
-  faCopy,
-  faCheck,
-} from "@fortawesome/free-solid-svg-icons";
+import Icon from "@/components/ui/Icon";
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
@@ -234,8 +228,8 @@ export const SingleSelect = React.forwardRef<HTMLDivElement, SingleSelectProps>(
                       aria-label={`Copy ${label} selection to clipboard`}
                       data-testid={`single-select-copy-${label.toLowerCase().replace(/\s+/g, '-')}`}
                     >
-                      <FontAwesomeIcon
-                        icon={faCopy}
+                      <Icon
+                        icon="copy"
                         className="text-[14px] text-[#3E88D5]"
                       />
                     </div>
@@ -268,13 +262,13 @@ export const SingleSelect = React.forwardRef<HTMLDivElement, SingleSelectProps>(
                     aria-label={`Clear ${label} selection`}
                     data-testid={`single-select-clear-${label.toLowerCase().replace(/\s+/g, '-')}`}
                   >
-                    <FontAwesomeIcon icon={faTimes} className="text-[11px]" />
+                    <Icon icon="times" className="text-[11px]" />
                   </div>
                 )}
                 {/* Dropdown arrow */}
                 <div className="flex w-[18px] h-4 px-[6px] justify-center items-center">
                   <div className="flex w-[10px] h-3 flex-col justify-center flex-shrink-0 text-[#545454] text-center">
-                    <FontAwesomeIcon icon={faCaretDown} className="text-base" />
+                    <Icon icon="caret-down" className="text-base" />
                   </div>
                 </div>
               </div>
@@ -316,7 +310,7 @@ export const SingleSelect = React.forwardRef<HTMLDivElement, SingleSelectProps>(
                   >
                     <span className="flex-1">{option.label}</span>
                     {value?.id === option.id && (
-                      <FontAwesomeIcon icon={faCheck} className="ml-2 text-white text-xs"  />
+                      <Icon icon="check" className="ml-2 text-white text-xs"  />
                     )}
                   </div>
                 ))

--- a/src/lib/iconMapping.ts
+++ b/src/lib/iconMapping.ts
@@ -61,6 +61,19 @@ import {
   faPenToSquare,
   faComment,
   faFileLines,
+  faChevronUp,
+  faChevronDown,
+  faChevronLeft,
+  faChevronRight,
+  faUser,
+  faXmark,
+  faUpload,
+  faCaretDown,
+  faCheck,
+  faListCheck,
+  faUserPlus,
+  faSearch,
+  faUpRightAndDownLeftFromCenter,
 } from "@fortawesome/free-solid-svg-icons";
 
 // Icon mapping from string names to FontAwesome icon objects
@@ -136,6 +149,23 @@ const iconMap: Record<string, IconDefinition> = {
   "pen-to-square": faPenToSquare,
   comment: faComment,
   "file-lines": faFileLines,
+  
+  // Navigation and UI icons
+  "chevron-up": faChevronUp,
+  "chevron-down": faChevronDown,
+  "chevron-left": faChevronLeft,
+  "chevron-right": faChevronRight,
+  "user": faUser,
+  "xmark": faXmark,
+  "times": faTimes, // Alias for xmark
+  "upload": faUpload,
+  "caret-down": faCaretDown,
+  "check": faCheck,
+  "list-check": faListCheck,
+  "user-plus": faUserPlus,
+  "search": faSearch,
+  "up-right-and-down-left-from-center": faUpRightAndDownLeftFromCenter,
+  "expand": faUpRightAndDownLeftFromCenter, // Alias for expand
 };
 
 // Function to get FontAwesome icon from icon name


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Replaces direct FontAwesomeIcon usage with the custom Icon component in several components to centralize icon management.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR continues the migration to use the unified `Icon` component, abstracting away direct FontAwesome imports and usage. This approach allows for easier future transitions between icon libraries or FontAwesome versions by centralizing icon definitions in `iconMapping.ts`.

---
<a href="https://cursor.com/background-agent?bcId=bc-16c0a33a-dfc3-44ed-9706-93fb65d4771a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16c0a33a-dfc3-44ed-9706-93fb65d4771a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>